### PR TITLE
Fixing host default value

### DIFF
--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -90,7 +90,7 @@ resource "aws_lb_listener" "frontend_http_tcp_redirect_no_logs" {
     type             = "redirect"
 
     redirect {
-      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))})}"
+      host        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_host", lookup(var.default_action_redirect_defaults, "host"))}"
       path        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_path", lookup(var.default_action_redirect_defaults, "path"))}"
       port        = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_port", lookup(var.default_action_redirect_defaults, "port"))}"
       protocol    = "${lookup(var.http_tcp_listeners_redirect[count.index], "redirect_protocol", lookup(var.default_action_redirect_defaults, "protocol"))}"


### PR DESCRIPTION
# PR o'clock

## Description

Fixed a typo where default options for the alb didnt work.

### Checklist

* [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [ ] Tests for the changes have been added and passing (for bug fixes/features)
* [ ] Test results are pasted in this PR (in lieu of CI)
* [ ] Docs have been added/updated (for bug fixes/features)
* [ ] Any breaking changes are noted in the description above
